### PR TITLE
Improve menu layout calculation

### DIFF
--- a/src/main/kotlin/pt/rafap/tEdit/datastore/TextBuffer.kt
+++ b/src/main/kotlin/pt/rafap/tEdit/datastore/TextBuffer.kt
@@ -1,6 +1,5 @@
 package pt.rafap.tEdit.datastore
 
-import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle
 import pt.rafap.tEdit.tui.TUI
 
 // Text Buffer using 2d array

--- a/src/main/kotlin/pt/rafap/tEdit/topbar/MenuNode.kt
+++ b/src/main/kotlin/pt/rafap/tEdit/topbar/MenuNode.kt
@@ -1,11 +1,7 @@
 package pt.rafap.tEdit.topbar
 
-import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle
-import jdk.javadoc.internal.doclets.toolkit.util.DocPath.parent
 import pt.rafap.tEdit.datastore.Cursor
 import pt.rafap.tEdit.tui.TUI
-import pt.rafap.tEdit.typeExt.center
-import kotlin.math.max
 
 open class MenuNode(
     val menuTitle: String,
@@ -56,14 +52,14 @@ open class MenuNode(
         }
 
     fun findMaxSize(): Int {
-        var maxSize = this.maxSize
-        for (child in childBuffer) {
-            val childSize = child.size
+        var maxSize = size
+        for (child in children) {
+            val childSize = child.findMaxSize()
             if (childSize > maxSize) {
                 maxSize = childSize
             }
         }
-        for (child in childBuffer) {
+        for (child in children) {
             child.maxSize = maxSize
         }
         this.maxSize = maxSize
@@ -114,14 +110,20 @@ open class MenuNode(
         childBuffer += child
     }
 
-    fun make(){
-
-        updatePosition()
-        findMaxSize()
-        updatePosition()
+    fun make() {
         for (child in childBuffer) {
+            child.parent = this
             children.add(child)
             child.make()
+        }
+        childBuffer.clear()
+        findMaxSize()
+    }
+
+    fun updatePositionsRecursive() {
+        updatePosition()
+        for (child in children) {
+            child.updatePositionsRecursive()
         }
     }
 

--- a/src/main/kotlin/pt/rafap/tEdit/topbar/MenuTree.kt
+++ b/src/main/kotlin/pt/rafap/tEdit/topbar/MenuTree.kt
@@ -25,6 +25,7 @@ class MenuTree(
 
     fun make(){
         root.make()
+        root.updatePositionsRecursive()
     }
 
     fun display(){


### PR DESCRIPTION
## Summary
- fix layout algorithm for MenuNode size and position
- make MenuTree recompute layout after building
- clean unused imports

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687454ddb4bc83328e0a997b3c8facc9